### PR TITLE
update source url for obtaining gatk 3.8

### DIFF
--- a/docker/install-gatk.sh
+++ b/docker/install-gatk.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 
 GATK_VERSION=3.8
 GATK_BUILD=1-0-gf15c1c3ef
-GATK_URL="https://software.broadinstitute.org/gatk/download/auth?package=GATK-archive&version=${GATK_VERSION}-${GATK_BUILD}"
+GATK_URL="https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-${GATK_VERSION}-${GATK_BUILD}.tar.bz2"
 GATK_TAR=GenomeAnalysisTK-${GATK_VERSION}.tar
 GATK_JAR=GenomeAnalysisTK.jar
 GATK_JAR_MD5=186aee868bb7cffc18007966ace8d053


### PR DESCRIPTION
DSP has updated the GATK website, breaking links to older versions. Tarballs for the older versions are preserved on GS with public links: https://console.cloud.google.com/storage/browser/gatk-software/package-archive/gatk
This commit updates the source url for the gatk 3.8 tarball to point to the new home on GS.