### PR TITLE
do not discard read IDs for single-end reads after running mvicuna

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -856,6 +856,10 @@ def mvicuna_fastqs_to_readlist(inFastq1, inFastq2, readList):
                         idVal = line.rstrip('\n')[1:]
                         if idVal.endswith('/1'):
                             outf.write(idVal[:-2] + '\n')
+                        # single-end reads do not have /1 /2 mate suffix
+                        # so pass through their IDs
+                        if not (idVal.endswith('/1') or idVal.endswith('/2')):
+                            outf.write(idVal + '\n')
                     line_num += 1
     os.unlink(outFastq1)
     os.unlink(outFastq2)


### PR DESCRIPTION
The old mvicuna post-processing code expects read IDs to have a `/1` mate suffix, and only includes those that do, which single-end reads do not have (nor interleaved fastqs, but that's a separate issue and we're generating the fastqs for this internal function ourselves so interleaving should not be an issue). So no single-end IDs were preserved. This PR ensures single-end read IDs make it through this post-processing.

Closes https://github.com/broadinstitute/viral-classify/issues/5