### PR TITLE
allow reports.pt::fastqc to output data zip archives

### DIFF
--- a/reports.py
+++ b/reports.py
@@ -1029,7 +1029,8 @@ __commands__.append(('align_and_plot_coverage', parser_align_and_plot_coverage))
 
 def parser_fastqc(parser=argparse.ArgumentParser()):
     parser.add_argument('inBam', help='Input reads, BAM format.')
-    parser.add_argument('outHtml', help='Output report, HTML format.')
+    parser.add_argument('out_html',  help='Output report, HTML format.')
+    parser.add_argument('--out_zip', help='Output data, zip archive.')
     util.cmd.attach_main(parser, tools.fastqc.FastQC().execute, split_args=True)
     return parser
 __commands__.append(('fastqc', parser_fastqc))

--- a/tools/fastqc.py
+++ b/tools/fastqc.py
@@ -29,11 +29,13 @@ class FastQC(tools.Tool):
     def version(self):
         return TOOL_VERSION
 
-    def execute(self, inBam, outHtml):    # pylint: disable=W0221
+    def execute(self, inBam, out_html, out_zip=None):    # pylint: disable=W0221
         if tools.samtools.SamtoolsTool().isEmpty(inBam):
             # fastqc can't deal with empty input
-            with open(outHtml, 'wt') as outf:
+            with open(out_html, 'wt') as outf:
                 outf.write("<html><body>Input BAM has zero reads.</body></html>\n")
+            if out_zip:
+                util.file.touch(out_zip)
 
         else:
             # run fastqc
@@ -45,5 +47,8 @@ class FastQC(tools.Tool):
                 log.debug(' '.join(tool_cmd))
                 subprocess.check_call(tool_cmd, stdout=sys.stderr)
                 expected_out = os.path.join(out_dir, os.path.basename(inBam)[:-4]) + "_fastqc.html"
-                shutil.copyfile(expected_out, outHtml)
+                shutil.copyfile(expected_out, out_html)
+                if out_zip:
+                    expected_out_zip = os.path.join(out_dir, os.path.basename(inBam)[:-4]) + "_fastqc.zip"
+                    shutil.copyfile(expected_out_zip, out_zip)
                 log.debug("complete")


### PR DESCRIPTION
allow reports.pt::fastqc to output data zip archives, as these files are used by downstream tools such as MultiQC