### PR TITLE
add --append_run_id to illumina_demux

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -865,7 +865,8 @@ class SampleSheet(object):
             else:
                 raise SampleSheetError('non-unique library IDs in this lane', infile)
         if self.append_run_id:
-            row['run'] += '.' + self.append_run_id
+            for row in self.rows:
+                row['run'] += '.' + self.append_run_id
 
         # escape sample, run, and library IDs to be filename-compatible
         for row in self.rows:


### PR DESCRIPTION
This adds a new --append_run_id boolean option to illumina_demux that causes output filenames to be appended with `.<flowcell_id>.<lane_num>`. It is off by default.