### PR TITLE
minimap2 empty output bam fix

### DIFF
--- a/tools/minimap2.py
+++ b/tools/minimap2.py
@@ -82,7 +82,7 @@ class Minimap2(tools.Tool):
             if len(align_bams)==0:
                 with util.file.tempfname('.empty.sam') as empty_sam:
                     samtools.dumpHeader(inBam, empty_sam)
-                    samtools.view(['-b'], empty_sam, outBam)
+                    samtools.sort(empty_sam, outBam)
             else:
                 # Merge BAMs, sort, and index
                 picardOptions = ['SORT_ORDER=coordinate', 'USE_THREADING=true', 'CREATE_INDEX=true']


### PR DESCRIPTION
When writing empty bam files, make sure the header says `SO:coordinate` instead of `SO:unsorted`, otherwise some downstream tools (such as Picard MarkDuplicates) will [complain](https://job-manager.dsde-prod.broadinstitute.org/jobs/108e6fb1-94ff-420c-94f2-2f79416c8d89) about it being unsorted (even though there are no reads).