### PR TITLE
minimap2 empty input bugfix

### DIFF
--- a/tools/minimap2.py
+++ b/tools/minimap2.py
@@ -182,8 +182,7 @@ class Minimap2(tools.Tool):
         # perform actual alignment
         if samtools.isEmpty(one_rg_inBam):
             # minimap doesn't like empty inputs, so copy empty bam through
-            outBam = one_rg_inBam
-            removeInput = False
+            samtools.sort(one_rg_inBam, outBam)
         else:
             self.align_cmd(one_rg_inBam, refDb, outBam, options=options, threads=threads)
 


### PR DESCRIPTION
fix minimap.align_one_rg when given an empty input bam with one read group (this previously worked fine when some read groups were empty in a multi RG bam, but didn't work with a single-RG empty input bam).