### PR TITLE
filter assembled reads in align_and_fix

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -1208,8 +1208,7 @@ def align_and_fix(
         else:
             aligner_options = '' # use defaults
 
-    input_readcount = samtools.count(inBam)
-    if input_readcount==0:
+    if samtools.isEmpty(inBam):
         log.warning("zero reads present in input")
 
     bam_aligned = mkstempfname('.aligned.bam')

--- a/read_utils.py
+++ b/read_utils.py
@@ -1208,6 +1208,12 @@ def align_and_fix(
         else:
             aligner_options = '' # use defaults
 
+    inBamFiltered = mkstempfname('.input-filtered.bam')
+    samtools.filter_to_mapped_reads(inBam, inBamFiltered, allow_unmapped=True)
+    filtered_count = samtools.count(inBamFiltered)
+    if filtered_count==0:
+        log.warning("zero reads after input filtering")
+
     bam_aligned = mkstempfname('.aligned.bam')
     if aligner=="novoalign":
         if novoalign_amplicons_bed is not None:
@@ -1216,7 +1222,7 @@ def align_and_fix(
         tools.novoalign.NovoalignTool(license_path=novoalign_license_path).index_fasta(refFastaCopy)
 
         tools.novoalign.NovoalignTool(license_path=novoalign_license_path).execute(
-            inBam, refFastaCopy, bam_aligned,
+            inBamFiltered, refFastaCopy, bam_aligned,
             options=aligner_options.split(),
             JVMmemory=JVMmemory
         )
@@ -1227,11 +1233,13 @@ def align_and_fix(
 
         opts = aligner_options.split()
 
-        bwa.align_mem_bam(inBam, refFastaCopy, bam_aligned, min_score_to_filter=bwa_min_score, threads=threads, options=opts)
+        bwa.align_mem_bam(inBamFiltered, refFastaCopy, bam_aligned, min_score_to_filter=bwa_min_score, threads=threads, options=opts)
 
     elif aligner=='minimap2':
         mm2 = tools.minimap2.Minimap2()
-        mm2.align_bam(inBam, refFastaCopy, bam_aligned, threads=threads, options=aligner_options.split())
+        mm2.align_bam(inBamFiltered, refFastaCopy, bam_aligned, threads=threads, options=aligner_options.split())
+
+    os.unlink(inBamFiltered)
 
     if skip_mark_dupes:
         bam_marked = bam_aligned
@@ -1256,7 +1264,7 @@ def align_and_fix(
         shutil.copyfile(bam_realigned, outBamAll)
         tools.picard.BuildBamIndexTool().execute(outBamAll)
     if outBamFiltered:
-        samtools.view(['-b', '-q', '1', '-F', '1028'], bam_realigned, outBamFiltered)
+        samtools.filter_to_mapped_reads(bam_realigned, outBamFiltered, allow_unmapped=False, min_mapping_qual=1)
         tools.picard.BuildBamIndexTool().execute(outBamFiltered)
     os.unlink(bam_realigned)
 

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -182,7 +182,7 @@ class SamtoolsTool(tools.Tool):
         opts = ['-b', '-F' '1028', '-f', '2', '-@', '3']
         self.view(opts, inBam, outBam)
 
-    def filter_to_mapped_reads(self, inBam, outBam, allow_unmapped=True, remove_singletons=True):
+    def filter_to_mapped_reads(self, inBam, outBam, allow_unmapped=True, min_mapping_qual=None, remove_singletons=True):
         '''
             This function writes a bam file filtered to include properly aligned reads.
             If allow_unmapped=True, fully-unmapped pairs or unmapped single-end reads are also 
@@ -202,6 +202,11 @@ class SamtoolsTool(tools.Tool):
                 for read in inb:
                     # check if a read is paired
                     is_single_end=not read.is_paired
+
+                    # only include reads with mapping quality >= INT
+                    # equivalent to samtools view -q
+                    if min_mapping_qual is not None and read.mapping_quality < min_mapping_qual:
+                        continue
 
                     # if a PCR/optical duplicate, do not write
                     if read.is_duplicate:

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -225,7 +225,7 @@ class SamtoolsTool(tools.Tool):
                             # reject pairs where both mates are unmapped
                             (read.mate_is_unmapped and read.is_unmapped) or
                             # reject reads where only one mate is mapped (singletons)
-                            (reject_singletons and read.mate_is_unmapped!=read.is_unmapped )):
+                            (reject_singletons and (read.mate_is_unmapped or read.is_unmapped))):
                         continue 
 
                     if is_single_end and read.is_unmapped: # or if this is single-end and unmapped, reject


### PR DESCRIPTION
* add `samtools.filter_to_mapped_reads()` function to remove duplicates, and reads that are not properly paired, with options to allow unmapped reads and singletons, and to filter based on mapping score
* in `read_utils.align_and_fix()`, replace `samtools -F 1028` with filters on input and output via samtools.filter_to_mapped_reads(), such that marked pcr duplicates and mapped singletons are removed on the input side, and on the output side marked duplicates are removed as well as any reads not properly paired, except for single-end reads, which are allowed through if mapped (or in any case if allow_unmapped=True). This is intended to address a specific issue where NovaSeq contamination presented as singleton reads. Input reads are filtered for the case where prior reads are realigned.
