### PR TITLE
demux meta_by_sample output fix

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -261,7 +261,7 @@ def main_illumina_demux(args):
         # organize samplesheet metadata as json
         if args.out_meta_by_sample:
             with open(args.out_meta_by_sample, 'wt') as outf:
-                json.dump(dict((r['sample_original'],r) for r in samples.get_rows()), outf, indent=2)
+                json.dump(dict((r['sample'],r) for r in samples.get_rows()), outf, indent=2)
         if args.out_meta_by_filename:
             with open(args.out_meta_by_filename, 'wt') as outf:
                 json.dump(dict((r['run'],r) for r in samples.get_rows()), outf, indent=2)


### PR DESCRIPTION
meta_by_sample should index on sanitized sample name, not original sample name