### PR TITLE
in tarball unpacking code, allow concatenated tarballs

### DIFF
--- a/util/file.py
+++ b/util/file.py
@@ -246,7 +246,16 @@ def extract_tarball(tarfile, out_dir=None, threads=None, compression='auto', pip
             decompressor = ['zstd', '-dc']
         elif compression == 'none':
             decompressor = ['cat']
-        untar_cmd = ['tar', '-C', out_dir, '-x']
+
+        untar_cmd = ['tar']
+        # always tolerate concatenated tarballs 
+        # (remove "True" to only allow for non-piped input)
+        if True or tarfile != '-': 
+            # --ignore-zeros to allow tarballs that have been made of other tarballs merged via simply
+            # calling 'cat' on them all
+            untar_cmd.extend(['--ignore-zeros'])
+        untar_cmd.extend(['-C', out_dir, '-x'])
+
         if os.getuid() == 0:
             # GNU tar behaves differently when run as root vs normal user
             # we want normal user behavior always


### PR DESCRIPTION
in tarball unpacking code, allow concatenated tarballs. Owing to tar's history as a way to create Tape ARchive backups, tar files can be joined by being concatenated together. The final block is padded with zeros though (indicating EOF), which can cause tar to terminate prematurely when concatenated tarballs are being unpacked unless it is told to tolerate these early stops. This adds the `--ignore-zeros` flag to make tarball extraction more permissive. Note: this applies only to uncompressed tarballs (including concatenated tarballs within compressed archives). Our tarball repacking code already tolerates such tarballs; background info here: https://github.com/broadinstitute/viral-ngs/pull/853#issuecomment-406634371