### PR TITLE
add jinja2>=2.11.3 to requirements

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -24,6 +24,7 @@ zstd>=1.3.8
 arrow>=0.12.1
 biopython>=1.72
 lz4=2.2.1
+jinja2>=2.11.3
 matplotlib>=2.2.4
 pysam>=0.16.0.1
 pybedtools>=0.7.10


### PR DESCRIPTION
add `jinja2>=2.11.3` to requirements for templating of various things, including [NCBI submission templates](https://submit.ncbi.nlm.nih.gov/genbank/template/submission/)