### PR TITLE
remove sequencer_model from illumina_demux run_info output

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -262,7 +262,6 @@ def main_illumina_demux(args):
                 'swath_count':runinfo.get_swath_count(),
                 'tile_count':runinfo.get_tile_count(),
                 'total_tile_count':runinfo.tile_count(),
-                'sequencer_model':runinfo.infer_sequencer_model(),
                 }, outf, indent=2)
 
     # manually garbage collect to make sure we have as much RAM free as possible


### PR DESCRIPTION
Remove the inferred sequencer model from out_runinfo json.