### PR TITLE
in illumina.py guess_barcodes, count NTCs by prefix if their count is not specified

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -601,11 +601,15 @@ def parser_guess_barcodes(parser=argparse.ArgumentParser()):
                         help='The fraction of reads expected to be assigned. An exception is raised if fewer than this fraction are assigned.',
                         type=float,
                         default=0.7)
-    parser.add_argument('--number_of_negative_controls',
-                        help='The number of negative controls in the pool, for calculating expected number of reads in the rest of the pool.',
-                        type=int,
-                        default=1)
-
+    group2 = parser.add_mutually_exclusive_group()
+    group2.add_argument('--number_of_negative_controls',
+                        help='If specified, the number of negative controls in the pool, for calculating expected number of reads in the rest of the pool.',
+                        type=int)
+    group2.add_argument('--neg_control_prefixes',
+                        nargs='+',
+                        help='If specified, the sample name prefixes assumed for counting negative controls. Case-insensitive.',
+                        type=str,
+                        default=["neg", "water", "NTC", "H2O"])
     parser.add_argument('--rows_limit',
                         default=1000,
                         type=int,
@@ -624,7 +628,8 @@ def main_guess_barcodes(in_barcodes,
                         expected_assigned_fraction, 
                         number_of_negative_controls, 
                         readcount_threshold, 
-                        rows_limit):
+                        rows_limit,
+                        neg_control_prefixes):
     """
         Guess the barcode value for a sample name,
             based on the following:
@@ -650,7 +655,8 @@ def main_guess_barcodes(in_barcodes,
                                                     outlier_threshold=outlier_threshold, 
                                                     expected_assigned_fraction=expected_assigned_fraction, 
                                                     number_of_negative_controls=number_of_negative_controls, 
-                                                    readcount_threshold=readcount_threshold)
+                                                    readcount_threshold=readcount_threshold,
+                                                    neg_control_prefixes=neg_control_prefixes)
     bh.write_guessed_barcodes(out_summary_tsv, guessed_barcodes)
 
 __commands__.append(('guess_barcodes', parser_guess_barcodes))

--- a/util/illumina_indices.py
+++ b/util/illumina_indices.py
@@ -2658,7 +2658,7 @@ class IlluminaBarcodeHelper(object):
         return out_dict
 
 
-    def find_uncertain_barcodes(self, sample_names=None, outlier_threshold=0.675, expected_assigned_fraction=0.7, number_of_negative_controls=1, readcount_threshold=None):
+    def find_uncertain_barcodes(self, sample_names=None, outlier_threshold=0.675, expected_assigned_fraction=0.7, number_of_negative_controls=None, readcount_threshold=None, neg_control_prefixes=None):
         """
             If sample_names is specified, barcodes for the named samples 
             will be re-examined. 
@@ -2668,12 +2668,17 @@ class IlluminaBarcodeHelper(object):
             If this is not specified, outliers will be detected automatically.
         """
         samples_to_examine = sample_names or []
+        neg_control_prefixes = neg_control_prefixes or ["neg", "water", "NTC", "H2O"]
+
+        inferred_ntc_count = [s.upper().startswith(tuple([p.upper() for p in neg_control_prefixes])) for s in self.sample_to_read_counts.keys()].count(True)
+
+        number_of_negative_controls = number_of_negative_controls or inferred_ntc_count
 
         guessed_barcodes = []
 
         if not samples_to_examine:
             if readcount_threshold:
-                for sample_name,count in self.sample_to_read_counts.values():
+                for sample_name,count in self.sample_to_read_counts.items():
                     if count < readcount_threshold:
                         samples_to_examine.append(sample_name)
             else:


### PR DESCRIPTION
in `illumina.py guess_barcodes`, this now counts NTCs by prefix if their count is not specified, defaulting to count samples starting with "neg", "water", "NTC", or "H2O" as negative controls. The user can specify their own prefix for negative controls via the newly-added "--neg_control_prefixes" argument, which is mutually-exclusive with "--number_of_negative_controls". If neither is specified, NTCs are counted based on prefix.