### PR TITLE
update coverage config and testing config inherited by derived docker images

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 omit = tools/conda-tools/*
 disable_warnings =
     module-not-imported
+relative_files = True
 
 [report]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GITHUB_ACTIONS_PYTHON_VERSION: "3.10"
-      PYTEST_ADDOPTS: "-rsxX -n 2 --durations=25 --fixture-durations=10 --junit-xml=pytest.xml --cov-report= --cov broad_utils --cov illumina --cov read_utils --cov reports --cov tools --cov util --cov file_utils"
+      PYTEST_ADDOPTS: "-rsxX --durations=25 --fixture-durations=10 --junit-xml=pytest.xml --cov-report= --cov broad_utils --cov illumina --cov read_utils --cov reports --cov tools --cov util --cov file_utils"
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -187,12 +187,9 @@ jobs:
           mkdir coverage
       - name: test with docker
         run: |
-          docker run -e _JAVA_OPTIONS -e PYTEST_ADDOPTS -v `pwd`/coverage:/coverage -v `pwd`/test:/opt/viral-ngs/source/test --entrypoint /bin/bash $DOCKER_TAG -c 'set -e; cd /opt/viral-ngs/source; pytest test/unit; cp .coverage /coverage'
-      - name: run coveralls
-        run: |
-          mv coverage/.coverage .
-          pip install coveralls>=1.3.0
-          coveralls --service=github
+          docker run -e _JAVA_OPTIONS -e PYTEST_ADDOPTS -v `pwd`/coverage:/coverage -v `pwd`/test:/opt/viral-ngs/source/test --entrypoint /bin/bash $DOCKER_TAG -c 'set -e; cd /opt/viral-ngs/source; pytest -n $(nproc) test/unit; cp .coverage /coverage'
+      - name: Run coveralls
+        uses: coverallsapp/github-action@v2
 
   ## note: this test_docs job does not actually produce the output on readthedocs
   ## readthedocs does its own build trigger. this job exists simply to alert us

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ nosetests.xml
 pytest.xml
 coverage.xml
 .coverage
+coverage/
 
 test/input/TestVPhaser2/in.bam.bti
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ htmlcov/
 nosetests.xml
 pytest.xml
 coverage.xml
-.coverage*
+.coverage
 
 test/input/TestVPhaser2/in.bam.bti
 

--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,10 @@ def pytest_configure(config):
     reporter = FixtureReporter(config)
     config.pluginmanager.register(reporter, 'fixturereporter')
 
+    config.addinivalue_line(
+        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
+    )
+
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runslow"):

--- a/requirements-conda-tests.txt
+++ b/requirements-conda-tests.txt
@@ -1,4 +1,4 @@
-coveralls>=1.3.0
+coveralls>=3.3.1
 lxml>=4.3.3
 mock>=2.0.0
 pytest>=7.4.3


### PR DESCRIPTION
update coverage config (.coveragerc) and testing config (conftest.py) inherited by derived docker images, set coveralls to use relative paths (since absolute paths reported by coveralls from tests within the docker container do not match those on the GitHub runner). This also sets the number of test runners to nproc rather than a hard-coded value