### PR TITLE
update viral-baseimage 0.2.2 -> 0.2.3 (with fully-featured qsv)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-baseimage:0.2.2
+FROM quay.io/broadinstitute/viral-baseimage:0.2.3
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -28,6 +28,7 @@ firecloud>=0.16.35
 lz4>=2.2.1
 jinja2>=2.11.3
 matplotlib>=2.2.4
+pandas
 pysam>=0.20.0
 pybedtools>=0.7.10
 zstandard>=0.15.2


### PR DESCRIPTION
update viral-baseimage 0.2.2 -> [0.2.3](https://github.com/broadinstitute/viral-baseimage/releases/tag/0.2.3) (containing fully-featured qsv)