### PR TITLE
more ReadTheDocs fixes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.10"
 
@@ -25,6 +25,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
+  version: "3.10"
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,6 +25,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.10"
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ __version__ = _git_version()
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.imgmath', 'sphinxarg.ext',]
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.imgmath', 'sphinxarg.ext', 'sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -122,7 +122,7 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
-    html_theme = 'default'
+    html_theme = 'sphinx_rtd_theme'
 else:
     import sphinx_rtd_theme
     html_theme = "sphinx_rtd_theme"


### PR DESCRIPTION
Our readthedocs configuration has fallen behind their required syntax -- update these. (build confirmed [here](https://readthedocs.org/projects/viral-core/builds/) with rendering [here](https://viral-core.readthedocs.io/en/docs/))