### PR TITLE
align_and_fix: tolerate whitespace in headers

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -1197,7 +1197,8 @@ def align_and_fix(
     samtools = tools.samtools.SamtoolsTool()
 
     refFastaCopy = mkstempfname('.ref_copy.fasta')
-    shutil.copyfile(util.file.fastas_with_sanitized_ids(refFasta, use_tmp=True).next(), refFastaCopy)
+    with util.file.fastas_with_sanitized_ids(refFasta, use_tmp=True) as sanitized_fastas:
+        shutil.copyfile(sanitized_fastas[0], refFastaCopy)
 
     tools.picard.CreateSequenceDictionaryTool().execute(refFastaCopy, overwrite=True, JVMmemory=JVMmemory)
     samtools.faidx(refFastaCopy, overwrite=True)

--- a/read_utils.py
+++ b/read_utils.py
@@ -1197,7 +1197,7 @@ def align_and_fix(
     samtools = tools.samtools.SamtoolsTool()
 
     refFastaCopy = mkstempfname('.ref_copy.fasta')
-    shutil.copyfile(util.file.fastas_with_sanitized_ids(refFasta, use_tmp=True)[0], refFastaCopy)
+    shutil.copyfile(util.file.fastas_with_sanitized_ids(refFasta, use_tmp=True).next(), refFastaCopy)
 
     tools.picard.CreateSequenceDictionaryTool().execute(refFastaCopy, overwrite=True, JVMmemory=JVMmemory)
     samtools.faidx(refFastaCopy, overwrite=True)

--- a/read_utils.py
+++ b/read_utils.py
@@ -1197,7 +1197,7 @@ def align_and_fix(
     samtools = tools.samtools.SamtoolsTool()
 
     refFastaCopy = mkstempfname('.ref_copy.fasta')
-    shutil.copyfile(refFasta, refFastaCopy)
+    shutil.copyfile(util.file.fastas_with_sanitized_ids(refFasta, use_tmp=True)[0], refFastaCopy)
 
     tools.picard.CreateSequenceDictionaryTool().execute(refFastaCopy, overwrite=True, JVMmemory=JVMmemory)
     samtools.faidx(refFastaCopy, overwrite=True)


### PR DESCRIPTION
This PR makes read_utils.align_and_fix tolerate whitespace and other unusual characters in the fasta sequence headers by sanitizing the headers prior to indexing and alignment.