### PR TITLE
add NCBI datasets to conda dependencies

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -13,6 +13,7 @@ lbzip2>=2.5
 lz4-c>=1.8.3
 minimap2>=2.17
 mvicuna=1.0
+ncbi-datasets-cli=16.33.0
 novoalign=3.09.04
 parallel>=20190922
 picard=2.25.6


### PR DESCRIPTION
add the [NCBI datasets](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/download-and-install/) CLI tools to conda dependencies, for downloading viral genomes and associated metadata