### PR TITLE
Fix fastqc to produce valid empty zip file for empty BAM inputs

### DIFF
--- a/test/unit/test_tools_fastqc.py
+++ b/test/unit/test_tools_fastqc.py
@@ -1,0 +1,126 @@
+# Unit tests for tools.fastqc
+
+__author__ = "dpark@broadinstitute.org"
+
+import unittest
+import os
+import zipfile
+from html.parser import HTMLParser
+import util.file
+import tools.fastqc
+from test import TestCaseWithTmp
+
+
+class HTMLValidator(HTMLParser):
+    """Simple HTML validator to check if HTML can be parsed without errors"""
+    def __init__(self):
+        super().__init__()
+        self.valid = True
+        self.error_msg = None
+
+    def error(self, message):
+        self.valid = False
+        self.error_msg = message
+
+
+class TestToolFastQC(TestCaseWithTmp):
+
+    def _validate_html(self, html_path):
+        """Validate that a file contains parseable HTML"""
+        with open(html_path, 'rt') as f:
+            html_content = f.read()
+
+        parser = HTMLValidator()
+        try:
+            parser.feed(html_content)
+            self.assertTrue(parser.valid, f"HTML parsing failed: {parser.error_msg}")
+        except Exception as e:
+            self.fail(f"HTML parsing raised exception: {e}")
+
+    def _validate_zip(self, zip_path):
+        """Validate that a file is a valid zip archive"""
+        try:
+            with zipfile.ZipFile(zip_path, 'r') as zf:
+                # testzip() returns None if the archive is valid
+                result = zf.testzip()
+                self.assertIsNone(result, f"ZIP validation failed: {result}")
+        except zipfile.BadZipFile as e:
+            self.fail(f"Invalid ZIP file: {e}")
+
+    def test_fastqc_nonempty_bam(self):
+        """Test FastQC on a non-empty BAM file"""
+        in_bam = os.path.join(util.file.get_test_input_path(), 'G5012.3.subset.bam')
+        out_html = util.file.mkstempfname('.html')
+        out_zip = util.file.mkstempfname('.zip')
+
+        fastqc = tools.fastqc.FastQC()
+        fastqc.execute(in_bam, out_html, out_zip=out_zip)
+
+        # Verify HTML file is created and non-empty
+        self.assertTrue(os.path.exists(out_html), "HTML output file should exist")
+        self.assertGreater(os.path.getsize(out_html), 0, "HTML file should not be empty")
+
+        # Validate HTML is parseable
+        self._validate_html(out_html)
+
+        # Verify ZIP file is created and is valid
+        self.assertTrue(os.path.exists(out_zip), "ZIP output file should exist")
+        self.assertGreater(os.path.getsize(out_zip), 0, "ZIP file should not be empty")
+
+        # Validate ZIP file
+        self._validate_zip(out_zip)
+
+        # Verify ZIP contains FastQC output files
+        with zipfile.ZipFile(out_zip, 'r') as zf:
+            namelist = zf.namelist()
+            self.assertGreater(len(namelist), 0, "ZIP should contain FastQC output files")
+
+    def test_fastqc_empty_bam(self):
+        """Test FastQC on an empty BAM file (zero reads)"""
+        in_bam = os.path.join(util.file.get_test_input_path(), 'empty.bam')
+        out_html = util.file.mkstempfname('.html')
+        out_zip = util.file.mkstempfname('.zip')
+
+        fastqc = tools.fastqc.FastQC()
+        fastqc.execute(in_bam, out_html, out_zip=out_zip)
+
+        # Verify HTML file is created and non-empty
+        self.assertTrue(os.path.exists(out_html), "HTML output file should exist")
+        self.assertGreater(os.path.getsize(out_html), 0, "HTML file should not be empty")
+
+        # Validate HTML is parseable
+        self._validate_html(out_html)
+
+        # Verify HTML contains expected message about empty input
+        with open(out_html, 'rt') as f:
+            html_content = f.read()
+            self.assertIn('zero reads', html_content.lower(), "HTML should mention zero reads")
+
+        # Verify ZIP file is created and is a valid (empty) zip
+        self.assertTrue(os.path.exists(out_zip), "ZIP output file should exist")
+
+        # A valid empty zip file should be 22 bytes (zip structure overhead)
+        self.assertEqual(os.path.getsize(out_zip), 22, "Empty ZIP should be 22 bytes (valid zip structure)")
+
+        # Validate ZIP file
+        self._validate_zip(out_zip)
+
+        # Verify ZIP has no files (empty)
+        with zipfile.ZipFile(out_zip, 'r') as zf:
+            namelist = zf.namelist()
+            self.assertEqual(len(namelist), 0, "Empty BAM should produce empty ZIP (0 files)")
+
+    def test_fastqc_without_zip(self):
+        """Test FastQC when --out_zip is not specified"""
+        in_bam = os.path.join(util.file.get_test_input_path(), 'G5012.3.subset.bam')
+        out_html = util.file.mkstempfname('.html')
+
+        fastqc = tools.fastqc.FastQC()
+        fastqc.execute(in_bam, out_html, out_zip=None)
+
+        # Verify HTML file is created
+        self.assertTrue(os.path.exists(out_html), "HTML output file should exist")
+        self.assertGreater(os.path.getsize(out_html), 0, "HTML file should not be empty")
+
+        # Validate HTML is parseable
+        self._validate_html(out_html)

--- a/tools/fastqc.py
+++ b/tools/fastqc.py
@@ -8,6 +8,7 @@ import os.path
 import shutil
 import subprocess
 import sys
+import zipfile
 
 import tools
 import tools.samtools
@@ -36,7 +37,8 @@ class FastQC(tools.Tool):
             with open(out_html, 'wt') as outf:
                 outf.write("<html><body>Input BAM has zero reads.</body></html>\n")
             if out_zip:
-                util.file.touch(out_zip)
+                with zipfile.ZipFile(out_zip, 'w') as zf:
+                    pass
 
         else:
             # run fastqc


### PR DESCRIPTION
## Summary
Fixes a bug where `reports.py fastqc` produces an invalid zip file when processing empty BAM files (zero reads).

## Problem
When `inBam` has zero reads, the `--out_zip` parameter was creating a 0-byte file using `util.file.touch()`, which is not a valid zip archive. This caused unzip failures:
```
End-of-central-directory signature not found.
```

## Solution
- Replace `util.file.touch(out_zip)` with `zipfile.ZipFile(out_zip, 'w')` to create a valid empty zip archive (22 bytes with proper zip structure)
- The fix mirrors the pattern used for HTML output, which already creates a properly formatted (albeit minimal) HTML file

## Testing
Added comprehensive test coverage in `test/unit/test_tools_fastqc.py`:
- `test_fastqc_nonempty_bam`: Validates normal FastQC operation on non-empty BAM
- `test_fastqc_empty_bam`: Validates empty BAM handling (the bug fix)
- `test_fastqc_without_zip`: Validates optional zip output

All tests validate HTML with `html.parser.HTMLParser` and ZIP with `zipfile.ZipFile.testzip()`.

## Verification
Before fix:
- `out.zip`: 0 bytes (invalid)
- Unzip result: ❌ Error

After fix:
- `out.zip`: 22 bytes (valid empty zip)
- Unzip result: ✅ Valid archive with 0 files
- Python zipfile module: ✅ Can read successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)