### PR TITLE
Fix illumina_metadata to support 3-barcode and mixed samplesheets

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -324,10 +324,13 @@ def illumina_metadata(
     runinfo_obj = RunInfo(runinfo)
 
     # Parse SampleSheet
+    # Note: allow_non_unique=True is needed for 3-barcode samplesheets where
+    # multiple samples share outer barcodes (barcode_1 + barcode_2) and differ
+    # only in inner barcodes (barcode_3)
     samples = SampleSheet(
         samplesheet,
         only_lane=lane,
-        allow_non_unique=False
+        allow_non_unique=True
     )
 
     output_files = {}


### PR DESCRIPTION
## Summary

This PR fixes a bug in `illumina_metadata` that prevented it from handling 3-barcode samplesheets used in splitcode demultiplexing workflows.

## Problem

The `illumina_metadata` function was failing on 3-barcode samplesheets where multiple samples share outer barcodes (barcode_1 + barcode_2) and differ only in inner barcodes (barcode_3).

**Root cause:** `SampleSheet` was being initialized with `allow_non_unique=False`, which raised a `SampleSheetError` when samples had duplicate outer barcode combinations.

## Solution

Changed `illumina_metadata()` to use `allow_non_unique=True` when loading samplesheets. This allows the function to properly handle:

1. **Traditional 2-barcode samplesheets** - barcode_1 + barcode_2 unique per sample
2. **3-barcode samplesheets** - barcode_1 + barcode_2 shared, barcode_3 unique per sample  
3. **Mixed samplesheets** - some samples with 3 barcodes, some with 2

## Test Coverage

Added 3 new test methods to `TestIlluminaMetadata`:

### `test_three_barcode_samplesheet`
Tests pure 3-barcode scenario where all samples share outer barcodes.

**Verifies:**
- ✅ Function handles duplicate outer barcodes without error
- ✅ All 7 samples included in metadata (from 3 pools)
- ✅ `barcode_3` field preserved in output
- ✅ `num_indexes = 2` (outer barcodes only)

### `test_mixed_two_and_three_barcode_samplesheet`  
Tests mixed scenario with both 2-barcode and 3-barcode samples.

**Verifies:**
- ✅ 6 samples with non-empty `barcode_3`
- ✅ 1 sample with empty `barcode_3` (TestSampleNoSplitcode)
- ✅ Both types handled correctly in same samplesheet

### `test_three_barcode_barcode_uniqueness`
Regression test ensuring duplicate outer barcodes don't cause errors.

**Verifies:**
- ✅ Pool 1 samples all share ATCGATCG+GCTAGCTA  
- ✅ All 4 Pool 1 samples present in metadata
- ✅ Each has unique `barcode_3` value

## Test Results

All 11 tests in `TestIlluminaMetadata` now pass:
- 8 existing tests (unchanged, still passing)
- 3 new tests (covering 3-barcode scenarios)

```bash
docker run --rm -v $(pwd):/opt/viral-ngs/source \
  quay.io/broadinstitute/viral-core:latest \
  pytest -xvs test/unit/test_illumina.py::TestIlluminaMetadata

# 11 passed in 0.45s
```

## Files Changed

- `illumina.py` - Fixed `allow_non_unique` parameter in `illumina_metadata()`
- `test/unit/test_illumina.py` - Added 3 new test methods to `TestIlluminaMetadata` class

## Impact

This fix ensures `illumina_metadata` works correctly with:
- **Splitcode demultiplexing workflows** (3-barcode samplesheets)
- **Traditional Illumina workflows** (2-barcode samplesheets)  
- **Mixed workflows** (hybrid samplesheets)

The function now properly generates metadata JSONs for all barcode configurations without requiring separate code paths or workarounds.
