### PR TITLE
Handle N bases in FASTQ barcodes and gracefully handle unmatched barcodes

### DIFF
--- a/test/unit/test_illumina.py
+++ b/test/unit/test_illumina.py
@@ -1079,17 +1079,17 @@ class TestBarcodeOrientationAutoDetection(unittest.TestCase):
         self.assertTrue(info['barcode_2_revcomp'])
         self.assertEqual(info['matched_bc2'], 'ACTGCAGCCG')
 
-    def test_no_match_raises_error(self):
-        """Test that ValueError is raised when no orientation matches."""
+    def test_no_match_returns_empty(self):
+        """Test that no match returns empty list with skipped_reason='no_match'."""
         sample_rows = [
             {'sample': 'S1', 'barcode_1': 'ATCGATCG', 'barcode_2': 'GCTAGCTA'},
         ]
         # Use completely different barcodes that won't match
-        with self.assertRaises(ValueError) as ctx:
-            illumina.match_barcodes_with_orientation(
-                'GGGGGGGG', 'CCCCCCCC', sample_rows
-            )
-        self.assertIn('No samples found matching', str(ctx.exception))
+        matched, info = illumina.match_barcodes_with_orientation(
+            'GGGGGGGG', 'CCCCCCCC', sample_rows
+        )
+        self.assertEqual(len(matched), 0)
+        self.assertEqual(info.get('skipped_reason'), 'no_match')
 
     def test_single_barcode_matching(self):
         """Test matching with only barcode_1 (barcode_2 is None)."""
@@ -1262,10 +1262,11 @@ class TestBarcodeOrientationAutoDetection(unittest.TestCase):
             {'sample': 'S1', 'barcode_1': 'ATCNATCG', 'barcode_2': 'GCTAGCTA'},
         ]
         # FASTQ has G where samplesheet has N - should not match
-        with self.assertRaises(ValueError):
-            illumina.match_barcodes_with_orientation(
-                'ATCGATCG', 'GCTAGCTA', sample_rows
-            )
+        matched, info = illumina.match_barcodes_with_orientation(
+            'ATCGATCG', 'GCTAGCTA', sample_rows
+        )
+        self.assertEqual(len(matched), 0)
+        self.assertEqual(info.get('skipped_reason'), 'no_match')
 
     def test_n_wildcard_no_false_positives(self):
         """Test that N wildcard doesn't cause incorrect matches."""


### PR DESCRIPTION
## Summary

This PR fixes demultiplexing failures when FASTQ barcodes contain N bases (sequencer no-call bases) or don't match any samplesheet entries. Previously these cases raised ValueError and caused Terra workflows to fail.

### Changes

**1. N-wildcard matching for FASTQ barcodes** (99636b93)
- Treat N bases in FASTQ header barcodes as wildcards that match any base
- This handles cases where the sequencer could not confidently call an index base
- Safety limits:
  - Barcodes with >50% N bases are rejected (too low confidence)
  - Ambiguous matches (N wildcard matching multiple distinct barcode pairs) are rejected
- N bases in the samplesheet do NOT act as wildcards (only observed FASTQ barcodes)

**2. Graceful handling of unmatched barcodes** (6acb8037)
- When barcodes do not match any samplesheet entries, produce empty BAM + metrics files instead of raising errors
- Applies to both 2-index and 3-index barcode paths
- Follows the same pattern already used for empty FASTQ file handling
- Allows workflows to complete successfully even with contaminant reads or barcode hopping

### Background

Analysis of 101 sharded demux tasks from a Terra run showed:
- 59 succeeded
- 37 failed due to barcode matching issues:
  - 30 (81%) failed due to N bases in barcodes (now fixed with N-wildcard matching)
  - 7 (19%) failed due to barcodes not in samplesheet (now returns empty output)

Example failing barcode: TAAGGAGGAA+AANGTCGGAA - the N at position 3 of barcode_2 prevented matching against samplesheet entry TAAGGAGGAA+AATGTCGGAA.

### New helper functions

- barcode_n_fraction(barcode) - Calculate fraction of N bases in a barcode
- barcode_matches_with_n(observed, expected) - Match with N-as-wildcard semantics

### Test coverage

Added 12 new unit tests covering:
- N-wildcard matching in barcode_1 and barcode_2
- N-wildcard with reverse complement orientation
- Multiple N wildcards in same barcode
- High N-fraction rejection (>50%)
- Ambiguous match detection
- N in samplesheet not acting as wildcard
- No-match returning empty results

All 126 illumina tests pass.

## Test plan

- [x] All existing unit tests pass
- [x] New unit tests for N-wildcard matching
- [x] New unit tests for no-match empty output behavior
- [ ] Re-run failed Terra workflow to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)