### PR TITLE
Fix merge queue Docker tag failures

### DIFF
--- a/github_actions_ci/list-docker-tags.sh
+++ b/github_actions_ci/list-docker-tags.sh
@@ -29,6 +29,13 @@ elif [ -n "$GITHUB_ACTIONS_PULL_REQUEST_BRANCH" ]; then
 	DOCKER_SHORT_TAG="$BRANCH_NAME-pull_request"
 	DOCKER_LONG_TAG="$(git describe --tags --always | sed s/^v//)-$(echo $DOCKER_SHORT_TAG)"
 	#DOCKER_LONG_TAG="$(git describe --tags --always | perl -lape 's/^v?(\S+)-(\d+)-g(\S+)/$1-beta$2-g$3/')-$(echo $BRANCH_NAME | sed 's/-/_/g')"
+elif [[ "$GITHUB_ACTIONS_BRANCH" == gh-readonly-queue/* ]]; then
+	# this is a merge queue commit (about to become master)
+	DOCKER_REPO=$DOCKER_REPO_DEV
+	# Extract PR number from branch name for tag clarity
+	PR_NUM=$(echo "$GITHUB_ACTIONS_BRANCH" | sed 's/.*pr-\([0-9]*\)-.*/\1/')
+	DOCKER_SHORT_TAG="merge-queue-pr-$PR_NUM"
+	DOCKER_LONG_TAG="$(git describe --tags --always | sed s/^v//)-merge-queue-pr-$PR_NUM"
 elif [[ "$GITHUB_ACTIONS_BRANCH" == "master" ]]; then
 	# this is a master branch commit (e.g. merged pull request)
 	DOCKER_REPO=$DOCKER_REPO_PROD


### PR DESCRIPTION
## Summary
- Docker image tags cannot contain forward slashes (`/`)
- Merge queue branches have names like `gh-readonly-queue/master/pr-128-...`
- This caused all merge queue builds to fail at the "Deploy docker image" step

This fix adds detection for merge queue branches and creates clean, valid Docker tags like `merge-queue-pr-128`.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Add this PR to the merge queue and confirm the merge queue build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)