### PR TITLE
Add threading to bam2fq_pipe and auto-compression to idxstats output

### DIFF
--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -83,8 +83,11 @@ class SamtoolsTool(tools.Tool):
         else:
             self.execute('bam2fq', ['-1', outFq1, '-2', outFq2, inBam])
 
-    def bam2fq_pipe(self, inBam):
-        tool_cmd = [self.install_and_get_path(), 'bam2fq', '-n', inBam]
+    def bam2fq_pipe(self, inBam, threads=None):
+        tool_cmd = [self.install_and_get_path(), 'bam2fq']
+        if threads is not None:
+            tool_cmd.extend(['-@', str(threads)])
+        tool_cmd.extend(['-n', inBam])
         log.debug(' '.join(tool_cmd) + ' |')
         p = subprocess.Popen(tool_cmd, stdout=subprocess.PIPE)
         return p


### PR DESCRIPTION
## Summary

Follow-up to #148 with minor enhancements to `minimap2_idxstats`:

- Add optional `threads` parameter to `samtools bam2fq_pipe()` for multi-threaded BAM decompression
- Use 4 threads for BAM decompression in `minimap2.idxstats()` to improve performance on compressed input
- Replace `open()` with `util.file.open_or_gzopen()` for output files to support automatic compression based on file extension (`.gz`, `.bz2`, `.zst`, `.lz4`)

## Test plan

- [x] All 9 minimap2 unit tests pass
- [x] Backward compatible: `bam2fq_pipe()` defaults to no threading (existing callers unaffected)
- [x] Backward compatible: uncompressed output files behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
