### PR TITLE
Fix rmdup_mvicuna_bam silently swallowing mvicuna failures

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -981,6 +981,7 @@ def rmdup_mvicuna_bam(inBam, outBam, JVMmemory=None, threads=None):
                 per_lb_read_lists.append(readList)
             except Exception as exc:
                 log.error('mvicuna process call generated an exception: %s' % (exc))
+                raise
 
     # merge per-library read lists together
     util.file.concat(per_lb_read_lists, readListAll)


### PR DESCRIPTION
## Summary
- Fix bug where rmdup_mvicuna_bam catches mvicuna exceptions but does not re-raise them
- Previously, when mvicuna failed (e.g., OOM killed), the function continued and produced an empty output BAM with exit code 0
- Now the exception is properly propagated after logging

## Test plan
- [ ] Run unit tests
- [ ] Verify that mvicuna failures now cause the workflow to fail with a non-zero exit code

Generated with Claude Code