### PR TITLE
Fix memory allocation in downsample_bams when processing fewer files than CPUs

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -402,7 +402,7 @@ def main_downsample_bams(in_bams, out_path, specified_read_count=None, deduplica
         return downsample_target
 
     def downsample_bams(data_pairs, downsample_target, threads=None, JVMmemory=None):
-        workers = util.misc.sanitize_thread_count(threads)
+        workers = min(util.misc.sanitize_thread_count(threads), len(data_pairs))
         JVMmemory = JVMmemory if JVMmemory else tools.picard.DownsampleSamTool.jvmMemDefault
         jvm_worker_memory_mb = str(int(util.misc.convert_size_str(JVMmemory,"m")[:-1])//workers)+"m"
         with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
@@ -416,7 +416,7 @@ def main_downsample_bams(in_bams, out_path, specified_read_count=None, deduplica
                     raise
 
     def dedup_bams(data_pairs, threads=None, JVMmemory=None):
-        workers = util.misc.sanitize_thread_count(threads)
+        workers = min(util.misc.sanitize_thread_count(threads), len(data_pairs))
         JVMmemory = JVMmemory if JVMmemory else tools.picard.DownsampleSamTool.jvmMemDefault
         jvm_worker_memory_mb = str(int(util.misc.convert_size_str(JVMmemory,"m")[:-1])//workers)+"m"
         with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:


### PR DESCRIPTION
## Summary
- Cap worker count to `min(sanitize_thread_count(threads), len(data_pairs))` in both `downsample_bams` and `dedup_bams` functions
- Prevents unnecessary division of JVM memory when processing fewer files than available CPUs
- Example: with 1 BAM on a 16-core machine, Picard now receives full memory instead of 1/16th

## Test plan
- [ ] Run `downsample_bams` with a single BAM file and verify Picard receives the full memory allocation
- [ ] Run with multiple BAM files and verify memory is still correctly divided among workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)