### PR TITLE
Migrate rmdup_cdhit_bam from Picard FastqToSam to samtools import

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -892,7 +892,10 @@ def rmdup_cdhit_bam(inBam, outBam, max_mismatches=None, jvm_memory=None):
         # before FastqToSamTool tries to read them
         cdhit.execute('cd-hit-dup', in_fastqs[0], out_fastqs[0], options=options, background=False)
 
-        tools.picard.FastqToSamTool().execute(out_fastqs[0], out_fastqs[1], f, out_bam, JVMmemory=jvm_memory)
+        tools.samtools.SamtoolsTool().import_fastq(
+            out_fastqs[0], out_fastqs[1], out_bam,
+            sample_name=f,
+        )
         for fn in in_fastqs:
             os.unlink(fn)
 


### PR DESCRIPTION
## Summary

- Replace Picard `FastqToSamTool` with `samtools import_fastq` in `rmdup_cdhit_bam()` for ~10x faster FASTQ→BAM conversion
- Completes migration started in PR #143, which already migrated `fastq_to_bam()` and the splitcode demux path

Fixes #144

## Test plan

- [x] Existing tests `test_cdhit_canned_input` and `test_cdhit_empty_input` pass
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)