### PR TITLE
Optimize filter_bam_by_ids: 6.7x faster with samtools pipes + SQLite batching

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -922,7 +922,7 @@ class ReadIdStore:
         )
         return cursor.fetchone() is not None
 
-    def contains_batch(self, read_ids, batch_size=50000):
+    def contains_batch(self, read_ids, batch_size=10000):
         """
         Check multiple read IDs for membership in batched queries.
 
@@ -1137,7 +1137,7 @@ class ReadIdStore:
         read_count = 0
         write_count = 0
         lookup_time = 0.0
-        batch_size = 100000
+        batch_size = 50000
 
         samtools_path = samtools.install_and_get_path()
 


### PR DESCRIPTION
## Summary

Optimizes `ReadIdStore.filter_bam_by_ids()` to be significantly faster:
- **355s** (this PR) vs **2372s** (master branch) = **6.7x faster**
- Now only 15% slower than Picard (310s), down from 7.7x slower
- **Beats Picard in exclude mode**: 630s vs 735s = **17% faster**

## Performance Results (100M reads, 7.4M read IDs)

### Include mode (keeping 14.6M reads, filtering out 91.7M)

| Approach | Total Time | Lookup Time | I/O Time | vs Picard |
|----------|------------|-------------|----------|-----------|
| Picard (2.5.18) | 310s | N/A | N/A | 1.0x |
| Master (pysam + per-read SQLite) | 2372s | 2035s | 337s | 7.7x slower |
| **This PR** | **355s** | **158s** | **197s** | **1.15x slower** |

### Exclude mode (keeping 91.7M reads, filtering out 14.6M)

| Approach | Total Time | Lookup Time | I/O Time | vs Picard |
|----------|------------|-------------|----------|-----------|
| Picard (2.5.18) | 735s | N/A | N/A | 1.0x |
| **This PR** | **630s** | **170s** | **460s** | **1.17x faster** |

The parallel BAM compression (`-@ 2`) provides greater benefit when writing more data, which is why we outperform Picard in exclude mode.

## Changes

1. **Hybrid I/O approach**: Use samtools subprocess pipes instead of pysam for BAM I/O
   - Avoids full AlignedSegment object parsing - only extracts QNAME field
   - Uses `--no-PG` flag to preserve exact headers

2. **Batched SQLite queries**: Query 50K read IDs at once instead of one-by-one
   - Reduces 100M queries to ~2K batched queries
   - Lookup time: 2035s → 158s (12.9x faster)

3. **SQLite performance PRAGMAs**: For tmpdir databases
   - `synchronous = OFF`, `journal_mode = OFF`
   - 64MB cache, temp tables in memory

4. **Parallel BAM compression**: `samtools view -@ 2` for multi-threaded output
   - I/O time reduced by 20%

5. **New `add_from_readlist()` method**: Load read IDs from a text file (one ID per line)
   - Used by `filter_bam` CLI command to load the read list into the SQLite store

6. **Code cleanup**: Module-level imports, DEBUG-level PERF logging

## Test plan

- [x] All existing unit tests pass (CI)
- [x] Benchmarked on 100M read BAM with 7.4M read ID filter list
- [x] Include mode: Output BAM verified to have correct read count (14,608,192 reads)
- [x] Exclude mode: Output BAM verified to have correct read count (91,688,456 reads)
- [x] Header preservation verified (no extra PG records added)