### PR TITLE
Fix CI race condition when release tag created during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ env:
 jobs:
   build_docker:
     runs-on: ubuntu-24.04
+    outputs:
+      docker_tag: ${{ steps.set_docker_tag.outputs.docker_tag }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -129,10 +131,15 @@ jobs:
       - name: Deploy docker image
         run: |
           github_actions_ci/deploy-docker.sh
-      - name: store tag ID in cache
+      - name: Set docker tag output
+        id: set_docker_tag
         run: |
+          DOCKER_TAG=$(github_actions_ci/list-docker-tags.sh | tail -1)
+          echo "docker_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+          echo "Docker tag for downstream jobs: $DOCKER_TAG"
+          # Also store in cache for future builds
           mkdir -p $CACHE_DIR
-          github_actions_ci/list-docker-tags.sh | tail -1 | tee $CACHE_DIR/old-docker-tag.txt
+          echo "$DOCKER_TAG" > $CACHE_DIR/old-docker-tag.txt
 
   test_in_docker:
     needs: build_docker
@@ -143,33 +150,6 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
-      # fetch git tags (tagged releases) because 
-      # actions/checkout@v3 does either a full checkout or a shallow checkout without tags
-      - name: fetch tags
-        run: git fetch --prune --unshallow --tags
-      - name: Programmatic environment setup
-        run: |
-          set -e -x
-          # $GITHUB_ENV is available for subsequent steps
-          GITHUB_ACTIONS_TAG=$(git describe --tags --exact-match && sed 's/^v//g' || echo '')
-          echo "GITHUB_ACTIONS_TAG=$GITHUB_ACTIONS_TAG" >> $GITHUB_ENV
-          # 
-          # Set GITHUB_ACTIONS_BRANCH
-          # TRAVIS_BRANCH: (via https://docs.travis-ci.com/user/environment-variables/ )
-          #   for push builds, or builds not triggered by a pull request, this is the name of the branch.
-          #   for builds triggered by a pull request this is the name of the branch targeted by the pull request.
-          #   for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).
-          # if GITHUB_ACTIONS_PULL_REQUEST_BRANCH is set, this is a pull request build
-          if [[ $GITHUB_ACTIONS_PULL_REQUEST_BRANCH ]]; then
-            GITHUB_ACTIONS_BRANCH=${GITHUB_ACTIONS_BASE_REF##*/}
-          # if event_name=="release", this is a tagged build
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_TAG
-          else
-            GITHUB_ACTIONS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          fi
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH"
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH" >> $GITHUB_ENV
       - name: install python
         uses: actions/setup-python@v5
         with:
@@ -179,7 +159,9 @@ jobs:
       - name: pull docker image
         run: |
           set -e -x
-          DOCKER_TAG=$(github_actions_ci/list-docker-tags.sh | tail -1)
+          # Use the exact Docker tag from the build job to avoid race conditions
+          # when a release tag is created between build_docker and test_in_docker
+          DOCKER_TAG="${{ needs.build_docker.outputs.docker_tag }}"
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
           echo "pulling $DOCKER_TAG"
           docker pull $DOCKER_TAG
@@ -201,39 +183,14 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
-      # fetch git tags (tagged releases) because 
-      # actions/checkout@v3 does either a full checkout or a shallow checkout without tags
-      - name: fetch tags
-        run: git fetch --prune --unshallow --tags
-      - name: Programmatic environment setup
-        run: |
-          set -e -x
-          # $GITHUB_ENV is available for subsequent steps
-          GITHUB_ACTIONS_TAG=$(git describe --tags --exact-match && sed 's/^v//g' || echo '')
-          echo "GITHUB_ACTIONS_TAG=$GITHUB_ACTIONS_TAG" >> $GITHUB_ENV
-          # 
-          # Set GITHUB_ACTIONS_BRANCH
-          # TRAVIS_BRANCH: (via https://docs.travis-ci.com/user/environment-variables/ )
-          #   for push builds, or builds not triggered by a pull request, this is the name of the branch.
-          #   for builds triggered by a pull request this is the name of the branch targeted by the pull request.
-          #   for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).
-          # if GITHUB_ACTIONS_PULL_REQUEST_BRANCH is set, this is a pull request build
-          if [[ $GITHUB_ACTIONS_PULL_REQUEST_BRANCH ]]; then
-            GITHUB_ACTIONS_BRANCH=${GITHUB_ACTIONS_BASE_REF##*/}
-          # if event_name=="release", this is a tagged build
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_TAG
-          else
-            GITHUB_ACTIONS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          fi
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH"
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: pull docker image
         run: |
           set -e -x
-          DOCKER_TAG=$(github_actions_ci/list-docker-tags.sh | tail -1)
+          # Use the exact Docker tag from the build job to avoid race conditions
+          # when a release tag is created between build_docker and test_docs
+          DOCKER_TAG="${{ needs.build_docker.outputs.docker_tag }}"
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
           echo "pulling $DOCKER_TAG"
           docker pull $DOCKER_TAG


### PR DESCRIPTION
## Summary

- Fixes a race condition where creating a GitHub release before `test_in_docker` starts causes CI to fail with "image not found" errors
- Passes Docker tag as job output from `build_docker` to downstream jobs instead of recalculating it
- Removes redundant git fetch and environment setup steps from `test_in_docker` and `test_docs`

## Problem

When merging a PR to master and then immediately creating a release tag (e.g., v2.5.21):

1. `build_docker` runs and builds an image tagged as `2.5.20-rc1` (based on `git describe`)
2. You create release v2.5.21, adding a new tag to the commit
3. `test_in_docker` runs later, does `git fetch --tags`, now sees v2.5.21
4. `git describe --tags --exact-match` succeeds because HEAD is now tagged
5. `list-docker-tags.sh` takes the "tagged release" path and tries to pull `viral-core:2.5.21`
6. Failure: That image doesn't exist - `build_docker` pushed `2.5.20-rc1`, not `2.5.21`

Re-running doesn't help because the tag permanently exists on that commit.

## Solution

Pass the Docker tag as a job output from `build_docker` to `test_in_docker` and `test_docs`, ensuring downstream jobs use the exact same tag that was built.

## Test plan

- [ ] CI passes on this PR
- [ ] After merging, verify that creating a release immediately after merging no longer causes CI failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)